### PR TITLE
Ignore non-standard import warning on */__init__.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ ignore = E203, E266, E302, E501, W503
 max-complexity = 18
 max-line-length = 79
 select = B, C, E, F, T4, W
+per-file-ignores = */__init__.py: F401, F403
 
 [isort]
 force_grid_wrap = 0
@@ -14,4 +15,3 @@ use_parentheses = true
 [mypy]
 files = src, test
 ignore_missing_imports = true
-


### PR DESCRIPTION
To avoid these warnings for every `__init__.py` file.

- `from module import *` (It is better not to use `*`)
- Imported but never used